### PR TITLE
Add PO spec.packageName description

### DIFF
--- a/api/v1alpha1/platformoperator_types.go
+++ b/api/v1alpha1/platformoperator_types.go
@@ -22,6 +22,8 @@ import (
 
 // PlatformOperatorSpec defines the desired state of PlatformOperator
 type PlatformOperatorSpec struct {
+	// PackageName specifies the name of the package to be installed from the provided CatalogSource.
+	// PackageName is required and must equal the exact name of the package in the catalog.
 	PackageName string `json:"packageName"`
 }
 

--- a/config/crd/bases/platform.openshift.io_platformoperators.yaml
+++ b/config/crd/bases/platform.openshift.io_platformoperators.yaml
@@ -37,6 +37,9 @@ spec:
             description: PlatformOperatorSpec defines the desired state of PlatformOperator
             properties:
               packageName:
+                description: PackageName specifies the name of the package to be installed
+                  from the provided CatalogSource. PackageName is required and must
+                  equal the exact name of the package in the catalog.
                 type: string
             required:
             - packageName


### PR DESCRIPTION
Adds a description to the `spec.packageName` field, making its purpose more clear to those reviewing the API. This change also adds the information to the generated PO CRD description, which can be then be viewed on-cluster via `kubectl explain`. 