### PR TITLE
controllers: Propagate the registry+v1 identifying information as Input annotations

### DIFF
--- a/controllers/cs_adapter_controller.go
+++ b/controllers/cs_adapter_controller.go
@@ -90,7 +90,13 @@ func (r *CatalogSourceAdapter) applyCandidateInput(ctx context.Context, b source
 	// TODO: ID becomes a field on the Input resource vs. relying on the metadata.Name internally?
 	//
 	// TODO: add a controller owner reference?
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, candidateInput, func() error {
+	_, err := controllerutil.CreateOrPatch(ctx, r.Client, candidateInput, func() error {
+		candidateInput.ObjectMeta.Annotations = map[string]string{
+			"deppy.adapter.catalog/image":       b.Image,
+			"deppy.adapter.catalog/channel":     b.ChannelName,
+			"deppy.adapter.catalog/source-name": b.SourceName,
+			"deppy.adapter.catalog/package":     b.PackageName,
+		}
 		candidateInput.Spec = deppyv1alpha1.InputSpec{
 			InputClassName: inputClassName,
 			Properties:     b.Properties,


### PR DESCRIPTION
Update the CS adapter logic, and ensure that the extra, registry+v1
bundle identifiable information is surfaced as Input
metadata.Annotations. This enables clients, e.g. a lookup service, to be
able to map an installed ID to an Input's metadata.Name, and access the
properties they care about.

In the case of a rukpak-focused client, we're mainly interested in
finding the bundle container image reference of the resolved Input
resource. Surfacing that container image as an annotation allows the
client to quickly lookup this property without iterating of an array
of the Input's spec.Properties.

In the future, we may want to re-think this approach, as other
resolution use cases may require building constraints on top of these
identifiable properties (e.g. a cluster invariant that only allows
bundles that belong to a specific channel).

Signed-off-by: timflannagan <timflannagan@gmail.com>