### PR TITLE
feat: Add basic status conditions management to the PO controller

### DIFF
--- a/controllers/cs_adapter_controller.go
+++ b/controllers/cs_adapter_controller.go
@@ -91,11 +91,14 @@ func (r *CatalogSourceAdapter) applyCandidateInput(ctx context.Context, b source
 	//
 	// TODO: add a controller owner reference?
 	_, err := controllerutil.CreateOrPatch(ctx, r.Client, candidateInput, func() error {
+		candidateInput.ObjectMeta.Labels = map[string]string{
+			"deppy.adapter.catalog/source-name":      b.SourceName,
+			"deppy.adapter.catalog/source-namespace": b.SourceNamespace,
+		}
 		candidateInput.ObjectMeta.Annotations = map[string]string{
-			"deppy.adapter.catalog/image":       b.Image,
-			"deppy.adapter.catalog/channel":     b.ChannelName,
-			"deppy.adapter.catalog/source-name": b.SourceName,
-			"deppy.adapter.catalog/package":     b.PackageName,
+			"deppy.adapter.catalog/image":   b.Image,
+			"deppy.adapter.catalog/channel": b.ChannelName,
+			"deppy.adapter.catalog/package": b.PackageName,
 		}
 		candidateInput.Spec = deppyv1alpha1.InputSpec{
 			InputClassName: inputClassName,

--- a/internal/sourcer/registry_sourcer.go
+++ b/internal/sourcer/registry_sourcer.go
@@ -101,15 +101,16 @@ func (s sources) GetCandidates(ctx context.Context) ([]Bundle, error) {
 				properties = append(properties, deppyv1alpha1.Property{Type: property.Type, Value: value})
 			}
 			candidates = append(candidates, Bundle{
-				Name:        b.GetCsvName(),
-				PackageName: b.GetPackageName(),
-				ChannelName: b.GetChannelName(),
-				Version:     b.GetVersion(),
-				Image:       b.GetBundlePath(),
-				Skips:       b.GetSkips(),
-				Replaces:    b.GetReplaces(),
-				SourceName:  cs.GetName(),
-				Properties:  properties,
+				Name:            b.GetCsvName(),
+				PackageName:     b.GetPackageName(),
+				ChannelName:     b.GetChannelName(),
+				Version:         b.GetVersion(),
+				Image:           b.GetBundlePath(),
+				Skips:           b.GetSkips(),
+				Replaces:        b.GetReplaces(),
+				SourceName:      cs.GetName(),
+				SourceNamespace: cs.GetNamespace(),
+				Properties:      properties,
 			})
 		}
 	}

--- a/internal/sourcer/sourcer.go
+++ b/internal/sourcer/sourcer.go
@@ -8,15 +8,16 @@ import (
 )
 
 type Bundle struct {
-	Name        string
-	PackageName string
-	ChannelName string
-	Version     string
-	Image       string
-	Replaces    string
-	Skips       []string
-	SourceName  string
-	Properties  []deppyv1alpha1.Property
+	Name            string
+	PackageName     string
+	ChannelName     string
+	Version         string
+	Image           string
+	Replaces        string
+	Skips           []string
+	SourceName      string
+	SourceNamespace string
+	Properties      []deppyv1alpha1.Property
 }
 
 func (b Bundle) String() string {

--- a/test/e2e/adapter_test.go
+++ b/test/e2e/adapter_test.go
@@ -1,0 +1,106 @@
+package e2e
+
+import (
+	"context"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	deppyv1alpha1 "github.com/operator-framework/deppy/api/v1alpha1"
+)
+
+var _ = FDescribe("catalog source deppy adapter", func() {
+	var (
+		ns      *corev1.Namespace
+		ctx     context.Context
+		catalog MagicCatalog
+	)
+	BeforeEach(func() {
+		ctx = context.Background()
+		ns = SetupTestNamespace(c, genName("e2e-"))
+
+		provider, err := NewFileBasedFiledBasedCatalogProvider(filepath.Join(dataBaseDir, "prometheus.v0.1.0.yaml"))
+		Expect(err).To(BeNil())
+
+		catalog = NewMagicCatalog(c, ns.GetName(), "prometheus", provider)
+		Expect(catalog.DeployCatalog(ctx)).To(BeNil())
+	})
+	AfterEach(func() {
+		Expect(c.Delete(ctx, ns)).To(BeNil())
+		Expect(catalog.UndeployCatalog(ctx)).To(BeNil())
+
+		// Note: hack around the CS adapter implementation that doesn't properly cleanup
+		// the generated set of Input resources
+		inputs := &deppyv1alpha1.InputList{}
+		Expect(c.List(ctx, inputs, &client.ListOptions{LabelSelector: newCatalogLabelSelector([]string{"prometheus"})})).To(BeNil())
+		for _, input := range inputs.Items {
+			input := input
+			Expect(c.Delete(ctx, &input)).To(BeNil())
+		}
+	})
+	When("a catalog source has been created", func() {
+		It("should create inputs for each package in the catalog", func() {
+			Eventually(func() bool {
+				inputs := &deppyv1alpha1.InputList{}
+				if err := c.List(ctx, inputs, &client.ListOptions{
+					LabelSelector: newCatalogLabelSelector([]string{"prometheus"}),
+				}); err != nil {
+					return false
+				}
+				// Note: there's a single olm.bundle defined in that testdata FBC
+				return len(inputs.Items) == 1
+			}).Should(BeTrue())
+		})
+		It("should generate an Input with the correct properties", func() {
+			Eventually(func() bool {
+				inputs := &deppyv1alpha1.InputList{}
+				if err := c.List(ctx, inputs, &client.ListOptions{
+					LabelSelector: newCatalogLabelSelector([]string{"prometheus"}),
+				}); err != nil {
+					return false
+				}
+				if len(inputs.Items) != 1 {
+					return false
+				}
+				input := inputs.Items[0]
+				if len(input.Spec.Properties) != 1 {
+					return false
+				}
+				property := input.Spec.Properties[0]
+				if property.Type != "olm.package" {
+					return false
+				}
+				return property.Value["package"] == "prometheus-operator"
+			}).Should(BeTrue())
+		})
+	})
+	// Note: skip this test for now until we come up with a better implementations,
+	// or refactor the adapter implementation to avoid creating Input resources through
+	// a Kubernetes API.
+	PWhen("a catalog source has been deleted", func() {
+		It("should delete an inputs that were sourced from that individual catalog", func() {
+			Eventually(func() bool {
+				inputs := &deppyv1alpha1.InputList{}
+				if err := c.List(ctx, inputs, &client.ListOptions{
+					LabelSelector: newCatalogLabelSelector([]string{"prometheus"}),
+				}); err != nil {
+					return false
+				}
+				return len(inputs.Items) == 0
+			}).Should(BeTrue())
+		})
+	})
+})
+
+func newCatalogLabelSelector(values []string) labels.Selector {
+	selector, err := labels.NewRequirement("deppy.adapter.catalog/source-name", selection.Equals, values)
+	if err != nil {
+		panic(err)
+	}
+	return labels.NewSelector().Add(*selector)
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	deppyv1alpha1 "github.com/operator-framework/deppy/api/v1alpha1"
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	platformv1alpha1 "github.com/timflannagan/platform-operators/api/v1alpha1"
 )
@@ -29,6 +30,10 @@ var (
 	c   client.Client
 )
 
+const (
+	dataBaseDir = "testdata"
+)
+
 var _ = BeforeSuite(func() {
 	cfg = ctrl.GetConfigOrDie()
 
@@ -37,6 +42,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).To(BeNil())
 
 	err = rukpakv1alpha1.AddToScheme(scheme)
+	Expect(err).To(BeNil())
+
+	err = deppyv1alpha1.AddToScheme(scheme)
 	Expect(err).To(BeNil())
 
 	err = operatorsv1alpha1.AddToScheme(scheme)

--- a/test/e2e/platform_operators_test.go
+++ b/test/e2e/platform_operators_test.go
@@ -14,10 +14,6 @@ import (
 	platformv1alpha1 "github.com/timflannagan/platform-operators/api/v1alpha1"
 )
 
-const (
-	dataBaseDir = "testdata"
-)
-
 var _ = Describe("platform operators controller", func() {
 	var (
 		ns  *corev1.Namespace


### PR DESCRIPTION
Updates the PO controllers, and ensure that resolution decisions are surfaced as status conditions. When resolutions fails, we should bubble up that status, and reset it when a successful resolution has occurred for the underlying Resolution object we're managing.

Refactor the Resolution requeue logic in the PO controllers, and avoid having explicit code that filters out POs that aren't named "cluster", as it's incompatible with our current testing suite, and that can be handled better at the caching layer.