### PR TITLE
*: Implement support for reconciling Operator version constraints

### DIFF
--- a/api/v1alpha1/operator_types.go
+++ b/api/v1alpha1/operator_types.go
@@ -32,7 +32,8 @@ type CatalogSpec struct {
 }
 
 type PackageSpec struct {
-	Name string `json:"name"`
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
 }
 
 // OperatorStatus defines the observed state of Operator

--- a/api/v1alpha1/operator_types.go
+++ b/api/v1alpha1/operator_types.go
@@ -56,6 +56,9 @@ type ActiveBundleDeployment struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:scope=Cluster
+//+kubebuilder:printcolumn:name="Active BundleDeployment",type=string,JSONPath=`.status.activeBundleDeployment.name`
+//+kubebuilder:printcolumn:name="Install State",type=string,JSONPath=`.status.conditions[?(.type=="Installed")].reason`
+//+kubebuilder:printcolumn:name=Age,type=date,JSONPath=`.metadata.creationTimestamp`
 
 // Operator is the Schema for the operators API
 type Operator struct {

--- a/config/crd/bases/core.olm.io_operators.yaml
+++ b/config/crd/bases/core.olm.io_operators.yaml
@@ -15,7 +15,17 @@ spec:
     singular: operator
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.activeBundleDeployment.name
+      name: Active BundleDeployment
+      type: string
+    - jsonPath: .status.conditions[?(.type=="Installed")].reason
+      name: Install State
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Operator is the Schema for the operators API

--- a/config/crd/bases/core.olm.io_operators.yaml
+++ b/config/crd/bases/core.olm.io_operators.yaml
@@ -59,6 +59,8 @@ spec:
                 properties:
                   name:
                     type: string
+                  version:
+                    type: string
                 required:
                 - name
                 type: object

--- a/config/samples/operator_v1alpha1_operator.yaml
+++ b/config/samples/operator_v1alpha1_operator.yaml
@@ -1,6 +1,38 @@
-apiVersion: operator.operator.io/v1alpha1
+apiVersion: core.olm.io/v1alpha1
 kind: Operator
 metadata:
-  name: operator-sample
+  name: crossplane-version-range
 spec:
-  # TODO(user): Add fields here
+  package:
+    name: universal-crossplane
+    version: "<2.0.0 || >=3.0.0"
+  catalog:
+    name: operatorhubio-catalog
+    namespace: olm
+
+---
+
+apiVersion: core.olm.io/v1alpha1
+kind: Operator
+metadata:
+  name: crossplane-highest-semver
+spec:
+  package:
+    name: universal-crossplane
+  catalog:
+    name: operatorhubio-catalog
+    namespace: olm
+
+---
+
+apiVersion: core.olm.io/v1alpha1
+kind: Operator
+metadata:
+  name: crossplane-explicit-version
+spec:
+  package:
+    name: universal-crossplane
+    version: "1.2.1-up.3"
+  catalog:
+    name: operatorhubio-catalog
+    namespace: olm

--- a/internal/controllers/operator_controller.go
+++ b/internal/controllers/operator_controller.go
@@ -131,10 +131,17 @@ func (r *OperatorReconciler) ensureDesiredBundleDeployment(ctx context.Context, 
 		if !apierrors.IsNotFound(err) {
 			return nil, err
 		}
+		// TODO: surface the sourced bundle version in the Operator's status.
 		sourcedBundle, err := r.Sourcer.Source(ctx, o)
 		if err != nil {
 			return nil, fmt.Errorf("%v: %w", err, errSourceFailed)
 		}
+
+		// TODO: Remove this debug artifact once upgrades are better supported,
+		// and this overall logic is refactored.
+		log := logr.FromContext(ctx)
+		log.Info("successfully sourced a registry+v1 bundle", "version", sourcedBundle.Version)
+
 		bd = applier.NewBundleDeployment(o, sourcedBundle.Image)
 		if err := r.Create(ctx, bd); err != nil {
 			return nil, err

--- a/test/e2e/operators_test.go
+++ b/test/e2e/operators_test.go
@@ -7,9 +7,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	platformtypes "github.com/timflannagan/platform-operators/api/v1alpha1"
@@ -33,7 +35,7 @@ var _ = Describe("operators controller", func() {
 			catalog MagicCatalog
 		)
 		BeforeEach(func() {
-			provider, err := NewFileBasedFiledBasedCatalogProvider(filepath.Join(dataBaseDir, "prometheus.v0.1.0.yaml"))
+			provider, err := NewFileBasedFiledBasedCatalogProvider(filepath.Join(dataBaseDir, "prometheus.v0.2.0.yaml"))
 			Expect(err).To(BeNil())
 
 			catalog = NewMagicCatalog(c, ns.GetName(), "prometheus", provider)
@@ -41,6 +43,132 @@ var _ = Describe("operators controller", func() {
 		})
 		AfterEach(func() {
 			Expect(catalog.UndeployCatalog(ctx)).To(BeNil())
+		})
+
+		When("an operator has been created with an explicit version specified", func() {
+			var (
+				o *platformtypes.Operator
+			)
+			BeforeEach(func() {
+				o = &platformtypes.Operator{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "valid-",
+					},
+					Spec: platformtypes.OperatorSpec{
+						Catalog: platformtypes.CatalogSpec{
+							Name:      "prometheus",
+							Namespace: ns.GetName(),
+						},
+						Package: platformtypes.PackageSpec{
+							Name:    "prometheus-operator",
+							Version: "0.1.0",
+						},
+					},
+				}
+				Expect(c.Create(ctx, o)).To(Succeed())
+			})
+			AfterEach(func() {
+				Expect(c.Delete(ctx, o)).To(Succeed())
+			})
+
+			It("should eventually result in a successful installation", func() {
+				Eventually(func() (*metav1.Condition, error) {
+					if err := c.Get(ctx, client.ObjectKeyFromObject(o), o); err != nil {
+						return nil, err
+					}
+					if o.Status.ActiveBundleDeployment.Name == "" {
+						return nil, fmt.Errorf("waiting for bundledeployment name to be populated")
+					}
+					return meta.FindStatusCondition(o.Status.Conditions, platformtypes.TypeInstalled), nil
+				}).Should(And(
+					Not(BeNil()),
+					WithTransform(func(c *metav1.Condition) string { return c.Type }, Equal(platformtypes.TypeInstalled)),
+					WithTransform(func(c *metav1.Condition) metav1.ConditionStatus { return c.Status }, Equal(metav1.ConditionTrue)),
+					WithTransform(func(c *metav1.Condition) string { return c.Reason }, Equal(platformtypes.ReasonInstallSuccessful)),
+				))
+			})
+
+			It("should generate a BundleDeployment that matches the expected version", func() {
+				Eventually(func() bool {
+					if err := c.Get(ctx, client.ObjectKeyFromObject(o), o); err != nil {
+						return false
+					}
+					bdName := o.Status.ActiveBundleDeployment.Name
+					if bdName == "" {
+						return false
+					}
+
+					bd := &rukpakv1alpha1.BundleDeployment{}
+					if err := c.Get(ctx, types.NamespacedName{Name: bdName}, bd); err != nil {
+						return false
+					}
+					// Note: this points to the v0.1.0 image.
+					return bd.Spec.Template.Spec.Source.Image.Ref == "quay.io/operatorhubio/prometheus:v0.47.0"
+				}).Should(BeTrue())
+			})
+		})
+
+		When("an operator has been created with a version range specified", func() {
+			var (
+				o *platformtypes.Operator
+			)
+			BeforeEach(func() {
+				o = &platformtypes.Operator{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "valid-",
+					},
+					Spec: platformtypes.OperatorSpec{
+						Catalog: platformtypes.CatalogSpec{
+							Name:      "prometheus",
+							Namespace: ns.GetName(),
+						},
+						Package: platformtypes.PackageSpec{
+							Name:    "prometheus-operator",
+							Version: ">0.1.0",
+						},
+					},
+				}
+				Expect(c.Create(ctx, o)).To(Succeed())
+			})
+			AfterEach(func() {
+				Expect(c.Delete(ctx, o)).To(Succeed())
+			})
+
+			It("should eventually result in a successful installation", func() {
+				Eventually(func() (*metav1.Condition, error) {
+					if err := c.Get(ctx, client.ObjectKeyFromObject(o), o); err != nil {
+						return nil, err
+					}
+					if o.Status.ActiveBundleDeployment.Name == "" {
+						return nil, fmt.Errorf("waiting for bundledeployment name to be populated")
+					}
+					return meta.FindStatusCondition(o.Status.Conditions, platformtypes.TypeInstalled), nil
+				}).Should(And(
+					Not(BeNil()),
+					WithTransform(func(c *metav1.Condition) string { return c.Type }, Equal(platformtypes.TypeInstalled)),
+					WithTransform(func(c *metav1.Condition) metav1.ConditionStatus { return c.Status }, Equal(metav1.ConditionTrue)),
+					WithTransform(func(c *metav1.Condition) string { return c.Reason }, Equal(platformtypes.ReasonInstallSuccessful)),
+				))
+			})
+
+			It("should generate a BundleDeployment that matches the expected version", func() {
+				Eventually(func() bool {
+					if err := c.Get(ctx, client.ObjectKeyFromObject(o), o); err != nil {
+						return false
+					}
+					bdName := o.Status.ActiveBundleDeployment.Name
+					if bdName == "" {
+						return false
+					}
+
+					bd := &rukpakv1alpha1.BundleDeployment{}
+					if err := c.Get(ctx, types.NamespacedName{Name: bdName}, bd); err != nil {
+						return false
+					}
+					// Note: this points to the v0.2.0 image.
+					return bd.Spec.Template.Spec.Source.Image.Ref == "quay.io/operatorhubio/prometheus:v0.47.0--20220413T184225"
+				}).Should(BeTrue())
+			})
 		})
 
 		When("a valid operator is created", func() {


### PR DESCRIPTION
Pushing up local changes that I had staged. Updates the Operator API and introduces an optional spec.package.version string field. When this field has been unspecified, the expected behavior is that the highest semver bundle that meets the package constraints will be returned.

The spec.package.version field supports a user specifying either an explicit version (e.g. "2.0.1") or a version range (e.g. "<2.0.0 || >=3.0.0"). When reconciling this value, we attempt to first check whether an explicit version has been specified through a simple regex, and then fall back to parsing a version range.